### PR TITLE
feat(sfdx-generator.ts): Minutes type return number

### DIFF
--- a/src/generator/sfdx-generator.ts
+++ b/src/generator/sfdx-generator.ts
@@ -158,8 +158,13 @@ export class Generator {
   }
 
   private extractType(flag: Flag): string {
-    if (flag.type === "flag") {
+    if (flag.type.startsWith("flag")) {
+      // Workaround for the flag noprompt in force:package:version:promote (was 'flag;' instead of 'flag')
       return "Boolean";
+    }
+
+    if (flag.type === "minutes") {
+      return "number";
     }
 
     if (flag.name === "loglevel") {


### PR DESCRIPTION
Minutes now return number instead of default string. Also adding a workaround for a specific bug
where 'flag;' type return string instead of Boolean.

BREAKING CHANGE: Minutes are now number, not string.