### PR TITLE
fix(sfdx-generator.ts): Separate flag workaround and add number type.

### DIFF
--- a/src/generator/sfdx-generator.ts
+++ b/src/generator/sfdx-generator.ts
@@ -161,12 +161,12 @@ export class Generator {
   }
 
   private extractType(flag: Flag): string {
-    if (flag.type.startsWith("flag")) {
+    if (flag.type === "flag" || flag.type === "flag;") {
       // Workaround for the flag noprompt in force:package:version:promote (was 'flag;' instead of 'flag')
       return "Boolean";
     }
 
-    if (flag.type === "minutes") {
+    if (flag.type === "number" || flag.type === "minutes") {
       return "number";
     }
 


### PR DESCRIPTION
In https://github.com/coveo/sfdx-generator/pull/5, `flag.type` can be undefined (in `force:lightning`) and stop the generator.

Add support to `number` parameter type.

BREAKING CHANGE: Number parameter type will be of type number instead of string.